### PR TITLE
V9/razor class librarify the maintenance mode template ! 

### DIFF
--- a/Our.Umbraco.MaintenanceMode/Controllers/MaintenanceModeController.cs
+++ b/Our.Umbraco.MaintenanceMode/Controllers/MaintenanceModeController.cs
@@ -19,7 +19,7 @@ namespace Our.Umbraco.MaintenanceMode.Controllers
         {
 
             Response.StatusCode = 503;
-            return View($"~/Views/{_maintenanceModeService.Settings.TemplateName}.cshtml", _maintenanceModeService.Settings.ViewModel);
+            return View($"/views/{_maintenanceModeService.Settings.TemplateName}.cshtml", _maintenanceModeService.Settings.ViewModel);
         }
 
         public MaintenanceModeController(IUmbracoContextAccessor umbracoContextAccessor, IUmbracoDatabaseFactory databaseFactory, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, IPublishedUrlProvider publishedUrlProvider, IMaintenanceModeService maintenanceModeService) 

--- a/Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
+++ b/Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
         <ContentTargetFolders>.</ContentTargetFolders>
         <Product>Our.Umbraco.MaintenanceMode</Product>
         <PackageId>Our.Umbraco.MaintenanceMode</PackageId>

--- a/Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
+++ b/Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
@@ -1,6 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+	<PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
         <ContentTargetFolders>.</ContentTargetFolders>
         <Product>Our.Umbraco.MaintenanceMode</Product>
         <PackageId>Our.Umbraco.MaintenanceMode</PackageId>
@@ -9,10 +10,15 @@
         <Product>...</Product>
         <PackageTags>umbraco plugin package</PackageTags>
         <RootNamespace>Our.Umbraco.MaintenanceMode</RootNamespace>
-    </PropertyGroup>
+
+		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+
+	</PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.3.0" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="9.3.0" />
         <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.3.0" />
     </ItemGroup>
 
@@ -25,13 +31,5 @@
             <Pack>True</Pack>
             <PackagePath>buildTransitive</PackagePath>
         </None>
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="Views\MaintenancePage.cshtml" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Resource Include="Views\MaintenancePage.cshtml" />
     </ItemGroup>
 </Project>

--- a/Our.Umbraco.MaintenanceMode/Views/MaintenancePage.cshtml
+++ b/Our.Umbraco.MaintenanceMode/Views/MaintenancePage.cshtml
@@ -1,5 +1,8 @@
-﻿@using Microsoft.AspNetCore.Http
-@inherits UmbracoViewPage<Our.Umbraco.MaintenanceMode.Models.MaintenanceMode>
+﻿@using Umbraco.Cms.Web.Common.Views
+@using Microsoft.AspNetCore.Html
+@using Microsoft.AspNetCore.Http
+@using Our.Umbraco.MaintenanceMode.Models
+@inherits UmbracoViewPage<MaintenanceMode>
 @{
     Layout = null;
 }


### PR DESCRIPTION
turn the package into a Razor Class Library, and then we can keep the template view out of peoples view folder! 

can be either overwritten by putting a maintenance.cshtml in the sites view folder, or picking a different template from the drop down.